### PR TITLE
Cleaner url maybe- works in docker without errorr

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "httpntlm": "1.7.3",
     "lodash": "4.17.2",
     "request": "2.79.0",
-    "soap": "git://github.com/nmarus/node-soap.git",
+    "soap": "https://github.com/nmarus/node-soap/tarball/master",
     "tmp": "0.0.28",
     "when": "3.7.7"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ews",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A simple JSON wrapper for the Exchange Web Services (EWS) SOAP API",
   "main": "./index.js",
   "scripts": {
@@ -12,13 +12,13 @@
     "httpntlm": "1.7.3",
     "lodash": "4.17.2",
     "request": "2.79.0",
-    "soap": "https://github.com/nmarus/node-soap/tarball/master",
+    "soap": "https://github.com/cumberlandgroup/node-soap/tarball/master",
     "tmp": "0.0.28",
     "when": "3.7.7"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nmarus/node-ews.git"
+    "url": "git+https://github.com/cumberlandgroup/node-ews.git"
   },
   "keywords": [
     "node",
@@ -31,7 +31,7 @@
     "json"
   ],
   "bugs": {
-    "url": "https://github.com/nmarus/node-ews/issues"
+    "url": "https://github.com/cumberlandgroup/node-ews/issues"
   },
-  "homepage": "https://github.com/nmarus/node-ews#readme"
+  "homepage": "https://github.com/cumberlandgroup/node-ews#readme"
 }


### PR DESCRIPTION
I'm not sure why, but this https-url works better when I run this package inside docker and node v.4 (argon).  It may have my personal issue but just for your information.  I think this is quite safe change.  In docker it's quite often so that git is not initialized ok or it needs some extra space to handle package.  By using  this /tarball/  it's directly usable for npm.  At least I would use this github's ability to build tarball.