### PR TITLE
Refix problem fixed

### DIFF
--- a/lib/ews.js
+++ b/lib/ews.js
@@ -111,7 +111,7 @@ EWS.prototype.init = function() {
   function fixWsdl(filePath) {
     // wsdl fix
     var wsdlFix = '\n<wsdl:service name="ExchangeServices">\n<wsdl:port name="ExchangeServicePort" binding="tns:ExchangeServiceBinding">\n<soap:address location="' + urlApi + '"/>\n</wsdl:port>\n</wsdl:service>\n</wsdl:definitions>';
-
+    var alreadyFixed = '<wsdl:service name="ExchangeServices">'
     // fix ms wdsl...
     // https://msdn.microsoft.com/en-us/library/office/aa580675.aspx
     // The EWS WSDL file, services.wsdl, does not fully conform to the WSDL standard
@@ -125,12 +125,16 @@ EWS.prototype.init = function() {
         else if(wsdl.search('<wsdl:definitions') == -1) reject(new Error('Invalid or malformed wsdl file: ' + filePath));
 
         else {
+          if (wsdl.search(alreadyFixed)==-1) { 
           // Remove </wsdl:definitions> and replace with our fix and
           // write file back to disk
           fs.writeFile(filePath, wsdl.replace("</wsdl:definitions>",wsdlFix), function(err) {
             if(err) reject(err);
             else resolve(filePath);
           });
+          } else {
+             resolve(filePath);
+          }   
         }
       });
     });


### PR DESCRIPTION
It seems that this fixWsdl is called many times. So this check prevents fixing (aka adding <wsdl:service name="ExchangeServices">-block multiple times to system).   Maybe there are better way to prevent system to call this fix-routine so many times?  reject this if you have some better approach :-)