### PR TITLE
Added logic to allow pre-encryption for NTLM authentication. 

### DIFF
--- a/lib/auth/ntlm.js
+++ b/lib/auth/ntlm.js
@@ -11,16 +11,26 @@ const HttpClient = require('./ntlm/http');
 
 // define ntlm auth
 const NTLMAuth = function(config, options) {
+  const passwordIsPlainText = _.has(config, 'password');
+  const passwordIsEncrypted = _.has(config, 'nt_password') && _.has(config, 'lm_password');
+
   if(typeof config === 'object'
     && _.has(config, 'host')
     && _.has(config, 'username')
-    && _.has(config, 'password')
+    && (passwordIsPlainText || passwordIsEncrypted)
   ) {
     return {
       wsdlOptions: { httpClient: HttpClient },
-      authProfile: new NtlmSecurity(config.username, config.password, options),
+      authProfile: new NtlmSecurity(config, options),
       getUrl: function(url, filePath) {
-        let ntlmOptions = { 'username': config.username, 'password': config.password };
+        let ntlmOptions = { 'username': config.username };
+        if (passwordIsPlainText) {
+          ntlmOptions.password = config.password;
+        }
+        else {
+          ntlmOptions.nt_password = config.nt_password;
+          ntlmOptions.lm_password = config.lm_password;
+        }
         ntlmOptions = _.merge(ntlmOptions, _.clone(options));
         ntlmOptions.url = url;
 

--- a/lib/auth/ntlm/ntlmSecurity.js
+++ b/lib/auth/ntlm/ntlmSecurity.js
@@ -2,11 +2,17 @@
 
 var _ = require('lodash');
 
-function ntlm(username, password, defaults) {
+function ntlm(config, defaults) {
     this.defaults = {
-      username: username,
-      password: password
+      username: config.username
     };
+    if (config.password) {
+        this.defaults.password = config.password;
+    }
+    else {
+        this.defaults.nt_password = config.nt_password;
+        this.defaults.lm_password = config.lm_password;
+    }
     _.merge(this.defaults, defaults);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ews",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A simple JSON wrapper for the Exchange Web Services (EWS) SOAP API",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
The underlying NTLM [lib](https://github.com/SamDecrock/node-http-ntlm) used by this module allows us to pass in the pre-encrypted `nt` and `lm` password hashes instead of the plain text password as [options](https://github.com/SamDecrock/node-http-ntlm#options). I added logic to take advantage of this feature. This saves us from having to persist the user's Exchange password in plain text when using NTLM. We now can reconnect using the hashed credentials from a persistent storage.