### PR TITLE
Fix notificationService

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ ews.notificationService(serviceOptions, function(response) {
   // Do something with response
   return {SendNotificationResult: { SubscriptionStatus: 'OK' } }; // respond with 'OK' to keep subscription alive
   // return {SendNotificationResult: { SubscriptionStatus: 'UNSUBSCRIBE' } }; // respond with 'UNSUBSCRIBE' to unsubscribe
-});
+})
 
 // The soap.listen object is passed through the promise so you can optionally use the .log() functionality
 // https://github.com/vpulim/node-soap#server-logging

--- a/lib/ews.js
+++ b/lib/ews.js
@@ -261,7 +261,7 @@ EWS.prototype.notificationService = function(options, callback) {
 
   if(_.has(options, 'xml') && options.xml !== '') {
     // merge user specified options with defaults
-    options = _.merge(ews[ews.auth].wsdlOptions, { port: 8000, path:'/notification' }, options);
+    options = _.merge(ews.auth.wsdlOptions, { port: 8000, path:'/notification' }, options);
   } else {
     throw new Error('options.xml is missing');
   }


### PR DESCRIPTION
The merge method between wsdlOptions and default values doesn't works.
Indeed, ews.auth is an object not a string and can't be use as a property of an object.