### PR TITLE
Fixes #106 Vuln deps fixed and confirm able to send emails

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Known Vulnerabilities](https://snyk.io//test/github/MatejMalicek/node-ews/badge.svg?targetFile=converter/package.json)](https://snyk.io//test/github/MatejMalicek/node-ews?targetFile=converter/package.json)
+
+Updated to v 3.2.5 on 4 September 2019 - vulnerable dependencies fixed.
+
 # node-ews
 ###### A simple JSON wrapper for the Exchange Web Services (EWS) SOAP API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Known Vulnerabilities](https://snyk.io//test/github/MatejMalicek/node-ews/badge.svg?targetFile=converter/package.json)](https://snyk.io//test/github/MatejMalicek/node-ews?targetFile=converter/package.json)
-
 Updated to v 3.2.5 on 4 September 2019 - vulnerable dependencies fixed.
 
 # node-ews

--- a/converter/package.json
+++ b/converter/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "lodash": "4.17.2",
+    "lodash": "4.17.12",
     "when": "3.7.7",
     "xml2js": "^0.4.17"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ews",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "A simple JSON wrapper for the Exchange Web Services (EWS) SOAP API",
   "main": "./index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "A simple JSON wrapper for the Exchange Web Services (EWS) SOAP API",
   "main": "./index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "snyk test"
   },
   "author": "Nicholas Marus",
   "license": "MIT",
   "dependencies": {
-    "debug": "2.3.3",
+    "debug": "^2.6.9",
     "httpntlm": "1.7.3",
-    "lodash": "4.17.2",
-    "request": "2.79.0",
-    "soap": "0.22.0",
+    "lodash": "^4.17.12",
+    "request": "^2.82.0",
+    "soap": "^0.24.0",
     "tmp": "0.0.28",
     "when": "3.7.7"
   },
@@ -34,5 +34,8 @@
   "bugs": {
     "url": "https://github.com/cumberlandgroup/node-ews/issues"
   },
-  "homepage": "https://github.com/cumberlandgroup/node-ews#readme"
+  "homepage": "https://github.com/cumberlandgroup/node-ews#readme",
+  "devDependencies": {
+    "snyk": "^1.224.0"
+  }
 }


### PR DESCRIPTION
As referred to in Issue #106 , this package has a number of vulnerable dependencies. The PR fixes these by updating the deps in the package.json file.

I patched them using Snyk & included it as a dev dependency. The "npm test" command (previously just said no test specified) now runs snyk test on the repo to check for vulnerable dependencies. This makes detection & patching much easier.